### PR TITLE
Optimizing List Performance in C# by Setting the Capacity Value

### DIFF
--- a/src/InsercaoRegistrosPessoas.cs
+++ b/src/InsercaoRegistrosPessoas.cs
@@ -52,7 +52,7 @@ public class InsercaoRegistrosPessoas
                 try
                 {
                     var batch = _conn.CreateBatch();
-                    var batchCommands = new List<NpgsqlBatchCommand>();
+                    var batchCommands = new List<NpgsqlBatchCommand>(pessoas.Count);
 
                     foreach (var p in pessoas)
                     {


### PR DESCRIPTION
## Description

This Pull Request (PR) addresses a little change to improve the performance optimization for C# code by enhancing the way we handle List objects. By proactively setting the initial capacity of a List when it's created, we can significantly improve its performance, especially in scenarios where the list will store a large number of items((I have an idea that it's not scenery because it only has 100 elements but I list started with the capacity of 4) 

## What does this PR do?

Introduces a change in our codebase to set the initial capacity of List objects when they are initialized.

reference about it: https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.-ctor?view=net-7.0#system-collections-generic-list-1-ctor(system-int32)

A good article about it: 
https://www.code4it.dev/csharptips/initialize-lists-size/

Feel free to modify or expand upon this description as needed to provide more specific details or context relevant to this project.